### PR TITLE
Add multi-spec configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
+# MCP Manager Examples
 
+This repository contains small demonstrations for working with the Model Context Protocol.
+
+## fastmcp_server
+
+A simple Python server built with [fastmcp](https://pypi.org/project/fastmcp/) that exposes an OpenAPI specification as MCP tools. See [`fastmcp_server/README.md`](fastmcp_server/README.md) for usage instructions.

--- a/fastmcp_server/README.md
+++ b/fastmcp_server/README.md
@@ -1,0 +1,39 @@
+# FastMCP Swagger Server
+
+This example demonstrates how to expose one or more OpenAPI specifications through the [FastMCP](https://pypi.org/project/fastmcp/) server. Each Swagger file is loaded and its endpoints are registered as MCP tools.
+
+## Requirements
+
+- Python 3.12
+- `fastmcp` package (`pip install fastmcp`)
+
+## Usage
+
+```bash
+pip install -r requirements.txt  # install dependencies
+python server.py                 # start the server
+```
+
+By default the server listens on port `3000` and serves SSE connections at `/sse` with messages posted to `/messages`. A simple health check is available at `/health`.
+
+The OpenAPI schemas to load are configured in `config.json`. Multiple specifications can be provided using the `swagger` array. Each entry requires a `file`, `apiBaseUrl` and a unique `prefix` used when mounting the tools.
+
+Example `config.json`:
+
+```json
+{
+  "swagger": [
+    {
+      "file": "examples/swagger-pet-store.json",
+      "apiBaseUrl": "https://petstore.swagger.io/v2",
+      "prefix": "petstore"
+    }
+  ],
+  "server": {
+    "host": "0.0.0.0",
+    "port": 3000
+  }
+}
+```
+
+Additional Swagger files can be added to the `swagger` list with different prefixes to combine multiple APIs into one MCP server.

--- a/fastmcp_server/config.json
+++ b/fastmcp_server/config.json
@@ -1,0 +1,13 @@
+{
+  "swagger": [
+    {
+      "file": "examples/swagger-pet-store.json",
+      "apiBaseUrl": "https://petstore.swagger.io/v2",
+      "prefix": "petstore"
+    }
+  ],
+  "server": {
+    "host": "0.0.0.0",
+    "port": 3000
+  }
+}

--- a/fastmcp_server/examples/swagger-pet-store.json
+++ b/fastmcp_server/examples/swagger-pet-store.json
@@ -1,0 +1,19 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/hello": {
+      "get": {
+        "summary": "Say hello",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        }
+      }
+    }
+  }
+}

--- a/fastmcp_server/requirements.txt
+++ b/fastmcp_server/requirements.txt
@@ -1,0 +1,2 @@
+fastmcp
+uvicorn

--- a/fastmcp_server/server.py
+++ b/fastmcp_server/server.py
@@ -1,0 +1,67 @@
+import json
+import os
+import asyncio
+from fastmcp import FastMCP
+from fastmcp.server.openapi import FastMCPOpenAPI
+from fastmcp.server.http import create_sse_app
+import httpx
+import uvicorn
+from starlette.responses import JSONResponse
+from starlette.requests import Request
+
+DEFAULT_CONFIG = {
+    "swagger": [
+        {
+            "file": "examples/swagger-pet-store.json",
+            "apiBaseUrl": "https://petstore.swagger.io/v2",
+            "prefix": "petstore"
+        }
+    ],
+    "server": {
+        "host": "0.0.0.0",
+        "port": 3000
+    }
+}
+
+def load_config(path: str = "config.json") -> dict:
+    if os.path.exists(path):
+        with open(path, "r", encoding="utf-8") as f:
+            cfg = json.load(f)
+    else:
+        cfg = DEFAULT_CONFIG
+    if isinstance(cfg.get("swagger"), dict):
+        cfg["swagger"] = [cfg["swagger"]]
+    return cfg
+
+async def main() -> None:
+    cfg = load_config(os.path.join(os.path.dirname(__file__), "config.json"))
+
+    root_server = FastMCP(name="Swagger MCP Server")
+
+    for spec_cfg in cfg["swagger"]:
+        file_path = os.path.join(os.path.dirname(__file__), spec_cfg["file"])
+        with open(file_path, "r", encoding="utf-8") as f:
+            spec = json.load(f)
+
+        client = httpx.AsyncClient(base_url=spec_cfg["apiBaseUrl"])
+
+        sub_server = FastMCPOpenAPI(
+            openapi_spec=spec,
+            client=client,
+            name=f"{spec_cfg.get('prefix', 'api')} server",
+        )
+
+        prefix = spec_cfg.get("prefix") or os.path.splitext(os.path.basename(spec_cfg["file"]))[0]
+        root_server.mount(prefix, sub_server)
+
+    @root_server.custom_route("/health", methods=["GET"])
+    async def health(_: Request):
+        return JSONResponse({"status": "ok"})
+
+    app = create_sse_app(server=root_server, message_path="/messages", sse_path="/sse")
+    config = uvicorn.Config(app, host=cfg["server"]["host"], port=cfg["server"]["port"])
+    server_uvicorn = uvicorn.Server(config)
+    await server_uvicorn.serve()
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- support multiple Swagger specs in fastmcp server config
- update example config and docs

## Testing
- `python fastmcp_server/server.py & sleep 5; pkill -f uvicorn`

------
https://chatgpt.com/codex/tasks/task_e_6856fa33937c8321beff4014f0a6e413