### PR TITLE
Add multi-server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
+# MCP Manager Examples
 
+This repository contains small demonstrations for working with the Model Context Protocol.
+
+## fastmcp_server
+
+A simple Python server built with [fastmcp](https://pypi.org/project/fastmcp/) that exposes an OpenAPI specification as MCP tools. See [`fastmcp_server/README.md`](fastmcp_server/README.md) for usage instructions.

--- a/fastmcp_server/README.md
+++ b/fastmcp_server/README.md
@@ -1,0 +1,47 @@
+# FastMCP Swagger Server
+
+This example demonstrates how to expose one or more OpenAPI specifications through the [FastMCP](https://pypi.org/project/fastmcp/) server. Each Swagger file is loaded and its endpoints are registered as MCP tools.
+
+## Requirements
+
+- Python 3.12
+- `fastmcp` package (`pip install fastmcp`)
+
+## Usage
+
+```bash
+pip install -r requirements.txt  # install dependencies
+python server.py [config.json or URL]
+```
+
+Alternatively set the `CONFIG_URL` environment variable to a file path or URL
+before running the server.
+
+By default the server listens on port `3000`. Each Swagger file becomes its own MCP server mounted under its configured `prefix`. SSE connections for a spec are available at `/<prefix>/sse` with messages posted to `/<prefix>/messages`. A combined server exposing all tools is also mounted at `/sse` and `/messages`. A simple health check is available at `/health`.
+
+The OpenAPI schemas to load are configured in `config.json`. Multiple specifications can be provided using the `swagger` array. Each entry requires either a `file` or `url`, an `apiBaseUrl` and a unique `prefix` used for the mount paths.
+
+Example `config.json`:
+
+```json
+{
+  "swagger": [
+    {
+      "file": "examples/swagger-pet-store.json",
+      "apiBaseUrl": "https://petstore.swagger.io/v2",
+      "prefix": "petstore"
+    },
+    {
+      "url": "https://example.com/other-openapi.json",
+      "apiBaseUrl": "https://example.com/api",
+      "prefix": "remote"
+    }
+  ],
+  "server": {
+    "host": "0.0.0.0",
+    "port": 3000
+  }
+}
+```
+
+Additional Swagger files can be added to the `swagger` list with different prefixes to combine multiple APIs into one MCP server. For example, a prefix of `petstore` will expose endpoints at `/petstore/sse` and `/petstore/messages`.

--- a/fastmcp_server/config.json
+++ b/fastmcp_server/config.json
@@ -1,0 +1,13 @@
+{
+  "swagger": [
+    {
+      "file": "examples/swagger-pet-store.json",
+      "apiBaseUrl": "https://petstore.swagger.io/v2",
+      "prefix": "petstore"
+    }
+  ],
+  "server": {
+    "host": "0.0.0.0",
+    "port": 3000
+  }
+}

--- a/fastmcp_server/examples/swagger-pet-store.json
+++ b/fastmcp_server/examples/swagger-pet-store.json
@@ -1,0 +1,43 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Petstore API",
+    "version": "1.0.0"
+  },
+  "servers": [{
+    "url": "https://petstore.swagger.io/v2"
+  }],
+  "paths": {
+    "/pet/findByStatus": {
+      "get": {
+        "operationId": "findPetsByStatus",
+        "summary": "Finds Pets by status",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["available", "pending", "sold"],
+                "default": "available"
+              }
+            },
+            "style": "form",
+            "explode": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          },
+          "400": {
+            "description": "Invalid status value"
+          }
+        }
+      }
+    }
+  }
+}

--- a/fastmcp_server/requirements.txt
+++ b/fastmcp_server/requirements.txt
@@ -1,0 +1,2 @@
+fastmcp
+uvicorn

--- a/fastmcp_server/server.py
+++ b/fastmcp_server/server.py
@@ -1,0 +1,122 @@
+import json
+import os
+import asyncio
+import sys
+from fastmcp import FastMCP
+from fastmcp.server.openapi import FastMCPOpenAPI
+from starlette.applications import Starlette
+from starlette.routing import Mount, Route
+import httpx
+import uvicorn
+from starlette.responses import JSONResponse
+from starlette.requests import Request
+
+DEFAULT_CONFIG = {
+    "swagger": [
+        {
+            "file": "examples/swagger-pet-store.json",
+            "apiBaseUrl": "https://petstore.swagger.io/v2",
+            "prefix": "petstore"
+        }
+    ],
+    "server": {
+        "host": "0.0.0.0",
+        "port": 3000
+    }
+}
+
+def load_config(source: str | None = None) -> dict:
+    """Load configuration from a local file or remote URL."""
+    if source is None:
+        source = os.environ.get("CONFIG_URL", "config.json")
+
+    if source.startswith("http://") or source.startswith("https://"):
+        try:
+            resp = httpx.get(source)
+            resp.raise_for_status()
+            cfg = resp.json()
+        except Exception as exc:
+            print(f"Failed to fetch config from {source}: {exc}")
+            cfg = DEFAULT_CONFIG
+    else:
+        if not os.path.isabs(source):
+            source = os.path.join(os.path.dirname(__file__), source)
+        if os.path.exists(source):
+            with open(source, "r", encoding="utf-8") as f:
+                cfg = json.load(f)
+        else:
+            cfg = DEFAULT_CONFIG
+
+    if isinstance(cfg.get("swagger"), dict):
+        cfg["swagger"] = [cfg["swagger"]]
+    return cfg
+
+async def main(config_source: str | None = None) -> None:
+    """Start the FastMCP server with configuration from a file or URL."""
+    if config_source is None:
+        # default to config.json in the same directory or CONFIG_URL env var
+        config_source = os.environ.get("CONFIG_URL", os.path.join(os.path.dirname(__file__), "config.json"))
+
+    cfg = load_config(config_source)
+
+    root_server = FastMCP(name="Swagger MCP Server")
+    app = Starlette()
+
+    for spec_cfg in cfg["swagger"]:
+        # Load the OpenAPI spec from a file or URL
+        if spec_cfg.get("file"):
+            file_path = spec_cfg["file"]
+            if not os.path.isabs(file_path):
+                file_path = os.path.join(os.path.dirname(__file__), file_path)
+            with open(file_path, "r", encoding="utf-8") as f:
+                spec = json.load(f)
+        elif spec_cfg.get("url"):
+            try:
+                resp = httpx.get(spec_cfg["url"])
+                resp.raise_for_status()
+                spec = resp.json()
+            except Exception as exc:
+                print(f"Failed to fetch spec {spec_cfg['url']}: {exc}")
+                continue
+        else:
+            print("Swagger config entry must include 'file' or 'url'")
+            continue
+
+        client = httpx.AsyncClient(base_url=spec_cfg["apiBaseUrl"])
+
+        sub_server = FastMCPOpenAPI(
+            openapi_spec=spec,
+            client=client,
+            name=f"{spec_cfg.get('prefix', 'api')} server",
+        )
+
+        if spec_cfg.get("prefix"):
+            prefix = spec_cfg["prefix"]
+        else:
+            if spec_cfg.get("file"):
+                prefix = os.path.splitext(os.path.basename(spec_cfg["file"]))[0]
+            else:
+                prefix = os.path.splitext(os.path.basename(spec_cfg["url"].split("?")[0]))[0]
+
+        # Mount tools into the shared root server
+        root_server.mount(prefix, sub_server)
+
+        # Mount individual SSE app for this swagger file
+        app.mount(f"/{prefix}", sub_server.sse_app())
+
+    async def health(_: Request):
+        return JSONResponse({"status": "ok"})
+
+    app.add_route("/health", health, methods=["GET"])
+
+    # Mount shared server at root (after /health route)
+    app.mount("/", root_server.sse_app())
+
+    config = uvicorn.Config(app, host=cfg["server"]["host"], port=cfg["server"]["port"])
+    server_uvicorn = uvicorn.Server(config)
+    await server_uvicorn.serve()
+
+if __name__ == "__main__":
+    # Optional config path or URL can be provided as the first argument
+    config_arg = sys.argv[1] if len(sys.argv) > 1 else None
+    asyncio.run(main(config_arg))


### PR DESCRIPTION
## Summary
- expose each Swagger spec on its own SSE endpoints
- keep combined server mounted at root
- update example spec to OpenAPI 3.1
- clarify mount paths in README
- support remote config and remote Swagger files

## Testing
- `pip install -r fastmcp_server/requirements.txt`
- `python fastmcp_server/server.py & sleep 5; pkill -f uvicorn`


------
https://chatgpt.com/codex/tasks/task_e_6856fa33937c8321beff4014f0a6e413