### PR TITLE
Refactor server with list-server endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.ruff_cache/
+.env
+.venv/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/fastmcp_server/README.md
+++ b/fastmcp_server/README.md
@@ -1,6 +1,6 @@
 # FastMCP Swagger Server
 
-This example demonstrates how to expose one or more OpenAPI specifications through the [FastMCP](https://pypi.org/project/fastmcp/) server. Each Swagger file is loaded and its endpoints are registered as MCP tools.
+This example demonstrates how to expose one or more OpenAPI specifications through the [FastMCP](https://pypi.org/project/fastmcp/) server. Each Swagger specification is loaded from a local path or URL and its endpoints are registered as MCP tools.
 
 ## Requirements
 
@@ -14,12 +14,18 @@ pip install -r requirements.txt  # install dependencies
 python server.py [config.json or URL]
 ```
 
+### Running tests
+
+```bash
+pytest
+```
+
 Alternatively set the `CONFIG_URL` environment variable to a file path or URL
 before running the server.
 
-By default the server listens on port `3000`. Each Swagger file becomes its own MCP server mounted under its configured `prefix`. SSE connections for a spec are available at `/<prefix>/sse` with messages posted to `/<prefix>/messages`. A combined server exposing all tools is also mounted at `/sse` and `/messages`. A simple health check is available at `/health`.
+By default the server listens on port `3000`. Each Swagger specification becomes its own MCP server mounted under its configured `prefix`. SSE connections for a spec are available at `/<prefix>/sse` with messages posted to `/<prefix>/messages`. A combined server exposing all tools is also mounted at `/sse` and `/messages`. A simple health check is available at `/health` and the list of available prefixes can be retrieved from `/list-server`.
 
-When the server starts it prints a short summary of how many tools were loaded for each Swagger file and the total number of tools across all specs:
+When the server starts it prints a short summary of how many tools were loaded for each Swagger specification and the total number of tools across all specs:
 
 ```
 Loaded N Swagger servers:
@@ -28,7 +34,7 @@ Loaded N Swagger servers:
 Total tools available: Z
 ```
 
-The OpenAPI schemas to load are configured in `config.json`. Multiple specifications can be provided using the `swagger` array. Each entry requires either a `file` or `url`, an `apiBaseUrl` and a unique `prefix` used for the mount paths.
+The OpenAPI schemas to load are configured in `config.json`. Multiple specifications can be provided using the `swagger` array. Each entry must include a `path` pointing to either a local file or a remote URL, an `apiBaseUrl` and a unique `prefix` used for the mount paths.
 
 Example `config.json`:
 
@@ -36,12 +42,12 @@ Example `config.json`:
 {
   "swagger": [
     {
-      "file": "examples/swagger-pet-store.json",
+      "path": "examples/swagger-pet-store.json",
       "apiBaseUrl": "https://petstore.swagger.io/v2",
       "prefix": "petstore"
     },
     {
-      "url": "https://example.com/other-openapi.json",
+      "path": "https://example.com/other-openapi.json",
       "apiBaseUrl": "https://example.com/api",
       "prefix": "remote"
     }
@@ -53,4 +59,4 @@ Example `config.json`:
 }
 ```
 
-Additional Swagger files can be added to the `swagger` list with different prefixes to combine multiple APIs into one MCP server. For example, a prefix of `petstore` will expose endpoints at `/petstore/sse` and `/petstore/messages`.
+Additional Swagger specifications can be added to the `swagger` list with different prefixes to combine multiple APIs into one MCP server. For example, a prefix of `petstore` will expose endpoints at `/petstore/sse` and `/petstore/messages`.

--- a/fastmcp_server/config.json
+++ b/fastmcp_server/config.json
@@ -1,7 +1,7 @@
 {
   "swagger": [
     {
-      "file": "examples/swagger-pet-store.json",
+      "path": "examples/swagger-pet-store.json",
       "apiBaseUrl": "https://petstore.swagger.io/v2",
       "prefix": "petstore"
     }

--- a/fastmcp_server/requirements.txt
+++ b/fastmcp_server/requirements.txt
@@ -1,2 +1,4 @@
 fastmcp
 uvicorn
+pytest
+pytest-httpx

--- a/fastmcp_server/server.py
+++ b/fastmcp_server/server.py
@@ -1,20 +1,25 @@
-import json
-import os
+"""FastMCP server exposing OpenAPI specs as MCP tools."""
+
 import asyncio
+import json
+import logging
+import os
 import sys
 from fastmcp import FastMCP
 from fastmcp.server.openapi import FastMCPOpenAPI
 from starlette.applications import Starlette
-from starlette.routing import Mount, Route
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 import httpx
 import uvicorn
-from starlette.responses import JSONResponse
-from starlette.requests import Request
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 DEFAULT_CONFIG = {
     "swagger": [
         {
-            "file": "examples/swagger-pet-store.json",
+            "path": "examples/swagger-pet-store.json",
             "apiBaseUrl": "https://petstore.swagger.io/v2",
             "prefix": "petstore"
         }
@@ -24,6 +29,30 @@ DEFAULT_CONFIG = {
         "port": 3000
     }
 }
+
+
+def _get_prefix(spec_cfg: dict) -> str:
+    """Return mount prefix for a swagger spec."""
+    if spec_cfg.get("prefix"):
+        return spec_cfg["prefix"]
+    path = spec_cfg.get("path", "")
+    base = os.path.basename(path.split("?")[0])
+    return os.path.splitext(base)[0]
+
+
+def _load_spec(spec_cfg: dict) -> dict:
+    """Load an OpenAPI specification from a path (local file or URL)."""
+    path = spec_cfg.get("path")
+    if not path:
+        raise ValueError("Swagger config entry must include 'path'")
+    if path.startswith("http://") or path.startswith("https://"):
+        resp = httpx.get(path)
+        resp.raise_for_status()
+        return resp.json()
+    if not os.path.isabs(path):
+        path = os.path.join(os.path.dirname(__file__), path)
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
 
 def load_config(source: str | None = None) -> dict:
     """Load configuration from a local file or remote URL."""
@@ -35,8 +64,8 @@ def load_config(source: str | None = None) -> dict:
             resp = httpx.get(source)
             resp.raise_for_status()
             cfg = resp.json()
-        except Exception as exc:
-            print(f"Failed to fetch config from {source}: {exc}")
+        except httpx.HTTPError as exc:
+            logger.error("Failed to fetch config from %s: %s", source, exc)
             cfg = DEFAULT_CONFIG
     else:
         if not os.path.isabs(source):
@@ -51,40 +80,24 @@ def load_config(source: str | None = None) -> dict:
         cfg["swagger"] = [cfg["swagger"]]
     return cfg
 
-async def main(config_source: str | None = None) -> None:
-    """Start the FastMCP server with configuration from a file or URL."""
-    if config_source is None:
-        # default to config.json in the same directory or CONFIG_URL env var
-        config_source = os.environ.get("CONFIG_URL", os.path.join(os.path.dirname(__file__), "config.json"))
 
-    cfg = load_config(config_source)
-
+async def create_app(cfg: dict) -> Starlette:
+    """Build and return the Starlette application for the given config."""
     root_server = FastMCP(name="Swagger MCP Server")
     app = Starlette()
 
     server_info: list[tuple[str, int]] = []
+    clients: list[httpx.AsyncClient] = []
 
     for spec_cfg in cfg["swagger"]:
-        # Load the OpenAPI spec from a file or URL
-        if spec_cfg.get("file"):
-            file_path = spec_cfg["file"]
-            if not os.path.isabs(file_path):
-                file_path = os.path.join(os.path.dirname(__file__), file_path)
-            with open(file_path, "r", encoding="utf-8") as f:
-                spec = json.load(f)
-        elif spec_cfg.get("url"):
-            try:
-                resp = httpx.get(spec_cfg["url"])
-                resp.raise_for_status()
-                spec = resp.json()
-            except Exception as exc:
-                print(f"Failed to fetch spec {spec_cfg['url']}: {exc}")
-                continue
-        else:
-            print("Swagger config entry must include 'file' or 'url'")
+        try:
+            spec = _load_spec(spec_cfg)
+        except (httpx.HTTPError, ValueError) as exc:
+            logger.error("Failed to load spec: %s", exc)
             continue
 
         client = httpx.AsyncClient(base_url=spec_cfg["apiBaseUrl"])
+        clients.append(client)
 
         sub_server = FastMCPOpenAPI(
             openapi_spec=spec,
@@ -94,40 +107,59 @@ async def main(config_source: str | None = None) -> None:
 
         tool_count = len(await sub_server.get_tools())
 
-        if spec_cfg.get("prefix"):
-            prefix = spec_cfg["prefix"]
-        else:
-            if spec_cfg.get("file"):
-                prefix = os.path.splitext(os.path.basename(spec_cfg["file"]))[0]
-            else:
-                prefix = os.path.splitext(os.path.basename(spec_cfg["url"].split("?")[0]))[0]
+        prefix = _get_prefix(spec_cfg)
 
         server_info.append((prefix, tool_count))
 
         # Mount tools into the shared root server
         root_server.mount(prefix, sub_server)
 
-        # Mount individual SSE app for this swagger file
+        # Mount individual SSE app for this swagger specification
         app.mount(f"/{prefix}", sub_server.sse_app())
 
-    print(f"Loaded {len(server_info)} Swagger servers:")
+    logger.info("Loaded %d Swagger servers:", len(server_info))
     for prefix, count in server_info:
-        print(f"  - {prefix}: {count} tools")
+        logger.info("  - %s: %d tools", prefix, count)
     try:
         total_tools = len(await root_server.get_tools())
-        print(f"Total tools available: {total_tools}")
-    except Exception:
-        pass
+        logger.info("Total tools available: %d", total_tools)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Failed to count tools: %s", exc)
 
     async def health(_: Request):
         return JSONResponse({"status": "ok"})
 
+    async def list_servers(_: Request):
+        return JSONResponse({"servers": [p for p, _ in server_info]})
+
     app.add_route("/health", health, methods=["GET"])
+    app.add_route("/list-server", list_servers, methods=["GET"])
 
     # Mount shared server at root (after /health route)
     app.mount("/", root_server.sse_app())
 
-    config = uvicorn.Config(app, host=cfg["server"]["host"], port=cfg["server"]["port"])
+    async def close_clients() -> None:
+        for client in clients:
+            await client.aclose()
+
+    app.add_event_handler("shutdown", close_clients)
+    return app
+
+async def main(config_source: str | None = None) -> None:
+    """Start the FastMCP server with configuration from a file or URL."""
+    if config_source is None:
+        # default to config.json in the same directory or CONFIG_URL env var
+        config_source = os.environ.get(
+            "CONFIG_URL",
+            os.path.join(os.path.dirname(__file__), "config.json"),
+        )
+
+    cfg = load_config(config_source)
+    app = await create_app(cfg)
+
+    config = uvicorn.Config(
+        app, host=cfg["server"]["host"], port=cfg["server"]["port"]
+    )
     server_uvicorn = uvicorn.Server(config)
     await server_uvicorn.serve()
 

--- a/fastmcp_server/tests/test_server.py
+++ b/fastmcp_server/tests/test_server.py
@@ -1,0 +1,92 @@
+import json
+import asyncio
+import httpx
+import pytest
+from fastmcp_server import server
+
+
+def test_load_config_local(tmp_path):
+    cfg_path = tmp_path / "config.json"
+    cfg_data = {"swagger": [], "server": {"host": "127.0.0.1", "port": 1234}}
+    cfg_path.write_text(json.dumps(cfg_data))
+    cfg = server.load_config(str(cfg_path))
+    assert cfg["server"]["port"] == 1234
+
+
+def test_load_config_remote(monkeypatch):
+    class FakeResp:
+        def __init__(self, data):
+            self._data = data
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._data
+
+    def fake_get(url):
+        return FakeResp({"swagger": [], "server": {"host": "0.0.0.0", "port": 9999}})
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    cfg = server.load_config("https://example.com/config.json")
+    assert cfg["server"]["port"] == 9999
+
+
+def test_get_prefix_from_file():
+    spec_cfg = {
+        "path": "examples/swagger-pet-store.json",
+        "apiBaseUrl": "https://example.com",
+    }
+    spec = server._load_spec(spec_cfg)
+    client = httpx.AsyncClient(base_url=spec_cfg["apiBaseUrl"])
+    sub_server = server.FastMCPOpenAPI(openapi_spec=spec, client=client)
+    tools = asyncio.run(sub_server.get_tools())
+    asyncio.run(client.aclose())
+    assert len(tools) > 0
+    assert server._get_prefix(spec_cfg) == "swagger-pet-store"
+
+
+def test_get_prefix_from_url(monkeypatch):
+    spec_data = {"openapi": "3.0.0", "paths": {}, "info": {"title": "t", "version": "1"}}
+
+    class FakeResp:
+        def __init__(self, data):
+            self._data = data
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._data
+
+    def fake_get(url):
+        return FakeResp(spec_data)
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    spec_cfg = {
+        "path": "https://example.com/pet.json",
+        "apiBaseUrl": "https://example.com",
+    }
+    spec = server._load_spec(spec_cfg)
+    client = httpx.AsyncClient(base_url=spec_cfg["apiBaseUrl"])
+    sub_server = server.FastMCPOpenAPI(openapi_spec=spec, client=client)
+    tools = asyncio.run(sub_server.get_tools())
+    asyncio.run(client.aclose())
+    assert len(tools) == 0
+    assert server._get_prefix(spec_cfg) == "pet"
+
+
+def test_list_server_endpoint():
+    cfg = server.load_config()
+
+    app = asyncio.run(server.create_app(cfg))
+
+    async def _call() -> httpx.Response:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            return await client.get("/list-server")
+
+    resp = asyncio.run(_call())
+    assert resp.status_code == 200
+    assert cfg["swagger"][0]["prefix"] in resp.json()["servers"]


### PR DESCRIPTION
## Summary
- add `/list-server` endpoint to return mounted prefixes
- restructure server startup into `create_app`
- document new endpoint
- test the `/list-server` route

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685713aaae48832195861ead2b2d6435