### PR TITLE
Switch starlette server to FastAPI

### DIFF
--- a/fastmcp_server/README.md
+++ b/fastmcp_server/README.md
@@ -6,6 +6,7 @@ This example demonstrates how to expose one or more OpenAPI specifications throu
 
 - Python 3.12
 - `fastmcp` package (`pip install fastmcp`)
+- `fastapi` package (`pip install fastapi`)
 
 ## Usage
 

--- a/fastmcp_server/requirements.txt
+++ b/fastmcp_server/requirements.txt
@@ -1,4 +1,5 @@
 fastmcp
+fastapi
 uvicorn
 pytest
 pytest-httpx

--- a/fastmcp_server/server.py
+++ b/fastmcp_server/server.py
@@ -7,9 +7,8 @@ import os
 import sys
 from fastmcp import FastMCP
 from fastmcp.server.openapi import FastMCPOpenAPI
-from starlette.applications import Starlette
-from starlette.requests import Request
-from starlette.responses import JSONResponse
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 import httpx
 import uvicorn
 
@@ -81,10 +80,10 @@ def load_config(source: str | None = None) -> dict:
     return cfg
 
 
-async def create_app(cfg: dict) -> Starlette:
-    """Build and return the Starlette application for the given config."""
+async def create_app(cfg: dict) -> FastAPI:
+    """Build and return the FastAPI application for the given config."""
     root_server = FastMCP(name="Swagger MCP Server")
-    app = Starlette()
+    app = FastAPI()
 
     server_info: list[tuple[str, int]] = []
     clients: list[httpx.AsyncClient] = []
@@ -132,8 +131,8 @@ async def create_app(cfg: dict) -> Starlette:
     async def list_servers(_: Request):
         return JSONResponse({"servers": [p for p, _ in server_info]})
 
-    app.add_route("/health", health, methods=["GET"])
-    app.add_route("/list-server", list_servers, methods=["GET"])
+    app.add_api_route("/health", health, methods=["GET"])
+    app.add_api_route("/list-server", list_servers, methods=["GET"])
 
     # Mount shared server at root (after /health route)
     app.mount("/", root_server.sse_app())


### PR DESCRIPTION
## Summary
- migrate server to FastAPI instead of Starlette
- document FastAPI as a requirement
- add FastAPI to requirements.txt

## Testing
- `python -m pytest -q fastmcp_server/tests`

------
https://chatgpt.com/codex/tasks/task_e_68584bf7456c8321b38cb12c8c04b778