### PR TITLE
Improve tool disable API

### DIFF
--- a/fastmcp_server/README.md
+++ b/fastmcp_server/README.md
@@ -102,3 +102,32 @@ variable) to a SQLAlchemy connection URL for a PostgreSQL database.
 Registered Swagger specs are stored in this database when added via
 `/add-server` and reloaded automatically on startup so no information is
 lost across restarts.
+
+### Disabling tools
+
+Individual tools can be enabled or disabled at runtime via the `/tool-enabled`
+endpoint. Send a POST request with a JSON body containing the tool `name`, the
+server `prefix` and the desired `enabled` state:
+
+```bash
+curl -X POST http://localhost:3000/tool-enabled \
+  -H "Content-Type: application/json" \
+  -d '{"prefix": "petstore", "name": "findPetsByStatus", "enabled": false}'
+```
+
+The state is persisted in the database so disabled tools remain disabled across
+server restarts.
+
+Tools can also be disabled programmatically using the FastMCP API:
+
+```python
+from fastmcp import FastMCP
+
+server = FastMCP(name="example")
+
+@server.tool
+def dynamic():
+    return "hi"
+
+dynamic.disable()  # re-enable later with dynamic.enable()
+```

--- a/fastmcp_server/db.py
+++ b/fastmcp_server/db.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
-from sqlalchemy import String, JSON, select
+from sqlalchemy import String, JSON, Boolean, select
 
 
 class Base(DeclarativeBase):
@@ -13,6 +13,15 @@ class Spec(Base):
     __tablename__ = "specs"
     prefix: Mapped[str] = mapped_column(String(100), primary_key=True)
     config: Mapped[dict] = mapped_column(JSON)
+
+
+class ToolStatus(Base):
+    """Store enable/disable state for individual tools."""
+
+    __tablename__ = "tools"
+    prefix: Mapped[str] = mapped_column(String(100), primary_key=True)
+    name: Mapped[str] = mapped_column(String(200), primary_key=True)
+    enabled: Mapped[bool] = mapped_column(Boolean, default=True)
 
 
 async def init_db(db_url: str) -> async_sessionmaker[AsyncSession]:
@@ -34,3 +43,21 @@ async def add_spec(session: AsyncSession, spec_cfg: dict) -> None:
         raise ValueError("spec config must include a prefix")
     await session.merge(Spec(prefix=prefix, config=spec_cfg))
     await session.commit()
+
+
+async def set_tool_enabled(
+    session: AsyncSession, prefix: str, name: str, enabled: bool
+) -> None:
+    """Insert or update a tool's enabled state."""
+    await session.merge(ToolStatus(prefix=prefix, name=name, enabled=enabled))
+    await session.commit()
+
+
+async def get_tool_statuses(
+    session: AsyncSession, prefix: str | None = None
+) -> list[ToolStatus]:
+    stmt = select(ToolStatus)
+    if prefix:
+        stmt = stmt.where(ToolStatus.prefix == prefix)
+    result = await session.scalars(stmt)
+    return list(result)


### PR DESCRIPTION
## Summary
- refine enabling/disabling logic to use `Tool.enable()`/`Tool.disable()`
- document programmatic tool disabling in README

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68586d92df808321ae57c25ff352f0f5