### PR TITLE
Improve FastAPI docs with Pydantic models

### DIFF
--- a/fastmcp_server/models.py
+++ b/fastmcp_server/models.py
@@ -1,0 +1,49 @@
+from pydantic import BaseModel
+
+
+class HealthResponse(BaseModel):
+    """Simple status response."""
+
+    status: str
+
+
+class ListServersResponse(BaseModel):
+    """Response model for list-server."""
+
+    servers: list[str]
+
+
+class ListToolsResponse(BaseModel):
+    """Response model for list-tools."""
+
+    tools: list[str]
+
+
+class AddServerRequest(BaseModel):
+    """Request body for adding a Swagger spec."""
+
+    path: str
+    apiBaseUrl: str
+    prefix: str | None = None
+
+
+class AddServerResponse(BaseModel):
+    """Response after adding a Swagger spec."""
+
+    added: str
+    tools: int
+
+
+class ToolEnabledRequest(BaseModel):
+    """Request body for enabling/disabling a tool."""
+
+    prefix: str
+    name: str
+    enabled: bool = False
+
+
+class ToolEnabledResponse(BaseModel):
+    """Response for tool-enabled state."""
+
+    tool: str
+    enabled: bool


### PR DESCRIPTION
## Summary
- use Pydantic models for request/response bodies
- expose typed models in OpenAPI
- update server routes to raise `HTTPException`
- wire models into `create_app`
- move models to `fastmcp_server/models.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858863361a48321ad192ca4a39abf8a