### PR TITLE
Add MCP dashboard

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,87 @@
+import gradio as gr
+import httpx
+
+API_URL = "http://localhost:3000"
+client = httpx.Client()
+
+def list_servers() -> list[str]:
+    try:
+        resp = client.get(f"{API_URL}/list-server")
+        resp.raise_for_status()
+        return resp.json().get("servers", [])
+    except Exception:
+        return []
+
+def list_tools(prefix: str) -> list[str]:
+    if not prefix:
+        return []
+    try:
+        resp = client.get(f"{API_URL}/list-tools", params={"prefix": prefix})
+        resp.raise_for_status()
+        return resp.json().get("tools", [])
+    except Exception:
+        return []
+
+def add_server(path: str, api_base: str, prefix: str) -> str:
+    data = {"path": path, "apiBaseUrl": api_base, "prefix": prefix or None}
+    try:
+        resp = client.post(f"{API_URL}/add-server", json=data)
+        resp.raise_for_status()
+        out = resp.json()
+        return f"Added {out['added']} with {out['tools']} tools"
+    except Exception as exc:
+        return f"Error: {exc}"
+
+def set_tool_enabled(prefix: str, tool: str, enabled: bool) -> str:
+    data = {"prefix": prefix, "name": tool, "enabled": enabled}
+    try:
+        resp = client.post(f"{API_URL}/tool-enabled", json=data)
+        resp.raise_for_status()
+        out = resp.json()
+        return f"Tool {out['tool']} enabled: {out['enabled']}"
+    except Exception as exc:
+        return f"Error: {exc}"
+
+def set_search_enabled(prefix: str, enabled: bool) -> str:
+    data = {"prefix": prefix, "enabled": enabled}
+    try:
+        resp = client.post(f"{API_URL}/search-enabled", json=data)
+        resp.raise_for_status()
+        out = resp.json()
+        return f"Search for {out['prefix']} enabled: {out['enabled']}"
+    except Exception as exc:
+        return f"Error: {exc}"
+
+with gr.Blocks(title="MCP Server Dashboard") as demo:
+    with gr.Tab("Add Server"):
+        path_in = gr.Textbox(label="Spec Path or URL")
+        api_in = gr.Textbox(label="API Base URL")
+        prefix_in = gr.Textbox(label="Prefix")
+        add_btn = gr.Button("Add")
+        add_out = gr.Textbox(label="Result")
+        add_btn.click(add_server, inputs=[path_in, api_in, prefix_in], outputs=add_out)
+
+    with gr.Tab("Tools"):
+        server_drop = gr.Dropdown(choices=list_servers(), label="Server")
+        refresh_btn = gr.Button("Refresh Servers")
+        tool_drop = gr.Dropdown(label="Tool")
+        enabled_chk = gr.Checkbox(label="Enabled", value=True)
+        set_btn = gr.Button("Set")
+        result_box = gr.Textbox(label="Result")
+
+        refresh_btn.click(lambda: gr.update(choices=list_servers()), None, server_drop)
+        server_drop.change(lambda p: gr.update(choices=list_tools(p)), server_drop, tool_drop)
+        set_btn.click(set_tool_enabled, inputs=[server_drop, tool_drop, enabled_chk], outputs=result_box)
+
+    with gr.Tab("Search"):
+        search_server = gr.Dropdown(choices=list_servers(), label="Server")
+        search_chk = gr.Checkbox(label="Search Enabled", value=True)
+        search_btn = gr.Button("Set")
+        search_out = gr.Textbox(label="Result")
+        search_refresh = gr.Button("Refresh Servers")
+
+        search_btn.click(set_search_enabled, inputs=[search_server, search_chk], outputs=search_out)
+        search_refresh.click(lambda: gr.update(choices=list_servers()), None, search_server)
+
+if __name__ == "__main__":
+    demo.launch()

--- a/fastmcp_server/models.py
+++ b/fastmcp_server/models.py
@@ -61,3 +61,16 @@ class SearchEnabledResponse(BaseModel):
 
     prefix: str
     enabled: bool
+
+
+class SearchResult(BaseModel):
+    """Single search result containing prefix and tool name."""
+
+    prefix: str
+    tool: str
+
+
+class SearchResponse(BaseModel):
+    """Response model for search endpoint."""
+
+    results: list[SearchResult]

--- a/fastmcp_server/models.py
+++ b/fastmcp_server/models.py
@@ -47,3 +47,17 @@ class ToolEnabledResponse(BaseModel):
 
     tool: str
     enabled: bool
+
+
+class SearchEnabledRequest(BaseModel):
+    """Request body for enabling/disabling search for a server."""
+
+    prefix: str
+    enabled: bool = False
+
+
+class SearchEnabledResponse(BaseModel):
+    """Response for search-enabled state."""
+
+    prefix: str
+    enabled: bool

--- a/fastmcp_server/routes.py
+++ b/fastmcp_server/routes.py
@@ -12,6 +12,7 @@ from .utils.openapi_utils import _get_prefix, _load_spec
 # Runtime storage for loaded OpenAPI specs and their configs
 spec_data: dict[str, dict] = {}
 spec_configs: dict[str, dict] = {}
+search_status: dict[str, bool] = {}
 
 
 HealthResponse = models.HealthResponse
@@ -157,4 +158,16 @@ def make_set_tool_enabled_handler(
         return ToolEnabledResponse(tool=name, enabled=bool(enabled))
 
     return set_tool_enabled
+
+
+def make_set_search_enabled_handler():
+    async def set_search_enabled(data: models.SearchEnabledRequest) -> models.SearchEnabledResponse:
+        """Enable or disable search for a server."""
+        prefix = data.prefix
+        if prefix not in spec_data:
+            raise HTTPException(status_code=404, detail="prefix not found")
+        search_status[prefix] = bool(data.enabled)
+        return models.SearchEnabledResponse(prefix=prefix, enabled=bool(data.enabled))
+
+    return set_search_enabled
 

--- a/fastmcp_server/server.py
+++ b/fastmcp_server/server.py
@@ -150,6 +150,12 @@ async def create_app(cfg: dict, db_url: str | None = None) -> FastAPI:
         methods=["POST"],
         response_model=models.ToolEnabledResponse,
     )
+    app.add_api_route(
+        "/search-enabled",
+        routes.make_set_search_enabled_handler(),
+        methods=["POST"],
+        response_model=models.SearchEnabledResponse,
+    )
 
     # Mount shared server at root (after /health route)
     app.mount("/", root_server.sse_app())

--- a/fastmcp_server/server.py
+++ b/fastmcp_server/server.py
@@ -156,6 +156,12 @@ async def create_app(cfg: dict, db_url: str | None = None) -> FastAPI:
         methods=["POST"],
         response_model=models.SearchEnabledResponse,
     )
+    app.add_api_route(
+        "/search",
+        routes.make_search_handler(root_server),
+        methods=["GET"],
+        response_model=models.SearchResponse,
+    )
 
     # Mount shared server at root (after /health route)
     app.mount("/", root_server.sse_app())

--- a/fastmcp_server/tests/test_server.py
+++ b/fastmcp_server/tests/test_server.py
@@ -219,3 +219,20 @@ def test_list_tools_endpoint():
     resp_all = asyncio.run(call_all())
     assert resp_all.status_code == 200
     assert len(resp_all.json()["tools"]) >= len(data["tools"])
+
+
+def test_search_enabled_endpoint():
+    cfg = server.load_config()
+    cfg["database"] = "sqlite+aiosqlite:///:memory:"
+
+    app = asyncio.run(server.create_app(cfg))
+    prefix = cfg["swagger"][0]["prefix"]
+
+    async def toggle() -> httpx.Response:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            return await client.post("/search-enabled", json={"prefix": prefix, "enabled": False})
+
+    resp = asyncio.run(toggle())
+    assert resp.status_code == 200
+    assert resp.json()["enabled"] is False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,4 +15,5 @@ dependencies = [
     "pytest>=8.4.1",
     "pytest-httpx>=0.35.0",
     "uvicorn>=0.34.3",
+    "gradio>=4.28.0",
 ]


### PR DESCRIPTION
## Summary
- add gradio dashboard for managing MCP servers
- allow toggling search status via new `/search-enabled` API
- include gradio in project dependencies
- test new endpoint

## Testing
- `pip install -q -r fastmcp_server/requirements.txt`
- `pip install -q psycopg2-binary`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858928c68708321a2602a3d7e614606